### PR TITLE
Add color selection through props for iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,12 @@ SketchView.constants = {
 SketchView.propTypes = {
   ...View.propTypes, // include the default view properties
   selectedTool: PropTypes.number,
+  toolColor: PropTypes.shape({
+    r: PropTypes.number.isRequired,
+    g: PropTypes.number.isRequired,
+    b: PropTypes.number.isRequired,
+    a: PropTypes.number.isRequired,
+  }),
   localSourceImagePath: PropTypes.string
 };
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import {
   View,
   UIManager,
   findNodeHandle,
-  DeviceEventEmitter 
+  DeviceEventEmitter,
+  ColorPropType, 
 } from 'react-native';
 
 class SketchView extends Component {
@@ -94,12 +95,7 @@ SketchView.constants = {
 SketchView.propTypes = {
   ...View.propTypes, // include the default view properties
   selectedTool: PropTypes.number,
-  toolColor: PropTypes.shape({
-    r: PropTypes.number.isRequired,
-    g: PropTypes.number.isRequired,
-    b: PropTypes.number.isRequired,
-    a: PropTypes.number.isRequired,
-  }),
+  toolColor: ColorPropType,
   localSourceImagePath: PropTypes.string
 };
 

--- a/ios/RNSketchViewManager.m
+++ b/ios/RNSketchViewManager.m
@@ -15,10 +15,10 @@ RCT_CUSTOM_VIEW_PROPERTY(selectedTool, NSInteger, SketchViewContainer)
     [currentView.sketchView setToolType:[RCTConvert NSInteger:json]];
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(toolColor, NSMutableDictionary, SketchViewContainer)
+RCT_CUSTOM_VIEW_PROPERTY(toolColor, UIColor, SketchViewContainer)
 {
     SketchViewContainer *currentView = !view ? defaultView : view;
-    [currentView.sketchView setToolColor:json];
+    [currentView.sketchView setToolColor:[RCTConvert UIColor:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(localSourceImagePath, NSString, SketchViewContainer)

--- a/ios/RNSketchViewManager.m
+++ b/ios/RNSketchViewManager.m
@@ -15,6 +15,12 @@ RCT_CUSTOM_VIEW_PROPERTY(selectedTool, NSInteger, SketchViewContainer)
     [currentView.sketchView setToolType:[RCTConvert NSInteger:json]];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(toolColor, NSMutableDictionary, SketchViewContainer)
+{
+    SketchViewContainer *currentView = !view ? defaultView : view;
+    [currentView.sketchView setToolColor:json];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(localSourceImagePath, NSString, SketchViewContainer)
 {
     SketchViewContainer *currentView = !view ? defaultView : view;

--- a/ios/SketchView/SketchView.h
+++ b/ios/SketchView/SketchView.h
@@ -14,6 +14,7 @@
 
 -(void) clear;
 -(void)setToolType:(SketchToolType) toolType;
+-(void)setToolColor:(NSMutableDictionary *)rgba;
 -(void)setViewImage:(UIImage *)image;
 
 @end

--- a/ios/SketchView/SketchView.m
+++ b/ios/SketchView/SketchView.m
@@ -52,6 +52,15 @@
     }
 }
 
+-(void)setToolColor:(NSMutableDictionary *)rgba
+{
+    float r = [[rgba objectForKey:@"r"] floatValue];
+    float g = [[rgba objectForKey:@"g"] floatValue];
+    float b = [[rgba objectForKey:@"b"] floatValue];
+    float a = [[rgba objectForKey:@"a"] floatValue];
+    [(PenSketchTool *)penTool setToolColor:[UIColor colorWithRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:a]];
+}
+
 -(void)setViewImage:(UIImage *)image
 {
     incrementalImage = image;

--- a/ios/SketchView/SketchView.m
+++ b/ios/SketchView/SketchView.m
@@ -52,13 +52,9 @@
     }
 }
 
--(void)setToolColor:(NSMutableDictionary *)rgba
+-(void)setToolColor:(UIColor *)rgba
 {
-    float r = [[rgba objectForKey:@"r"] floatValue];
-    float g = [[rgba objectForKey:@"g"] floatValue];
-    float b = [[rgba objectForKey:@"b"] floatValue];
-    float a = [[rgba objectForKey:@"a"] floatValue];
-    [(PenSketchTool *)penTool setToolColor:[UIColor colorWithRed:r/255.0 green:g/255.0 blue:b/255.0 alpha:a]];
+    [(PenSketchTool *)penTool setToolColor:rgba];
 }
 
 -(void)setViewImage:(UIImage *)image


### PR DESCRIPTION
This is meant to be a companion to the current PR #5 that is in for Android.  I noticed that it uses the integer representation in the props, which didn't seem very user friendly to me.  In this PR I use a NSMutableDictionary with the RGBA information - the Android PR could use this too, and just transform it to a color integer