### PR TITLE
Support for React Native 0.47

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSketchViewPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNSketchViewPackage.java
@@ -18,11 +18,6 @@ public class RNSketchViewPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(new RNSketchViewManager());
     }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 import React, { PropTypes, Component } from 'react';
 import {
   requireNativeComponent,
-  View,
+  ViewPropTypes,
   UIManager,
   findNodeHandle,
   DeviceEventEmitter

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 
 import React, { PropTypes, Component } from 'react';
-import { 
-  requireNativeComponent, 
+import {
+  requireNativeComponent,
   View,
   UIManager,
   findNodeHandle,
-  DeviceEventEmitter 
+  DeviceEventEmitter
 } from 'react-native';
 
 class SketchView extends Component {
@@ -92,7 +92,7 @@ SketchView.constants = {
 };
 
 SketchView.propTypes = {
-  ...View.propTypes, // include the default view properties
+  ...ViewPropTypes, // include the default view properties
   selectedTool: PropTypes.number,
   localSourceImagePath: PropTypes.string
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import {
   requireNativeComponent,
   ViewPropTypes,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "homepage": "https://github.com/keshavkaul/react-native-sketch-view#readme",
 
   "peerDependencies": {
-    "react-native": "^0.45.0"
+    "react-native": "^0.42"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "url": "https://github.com/keshavkaul/react-native-sketch-view/issues"
   },
   "homepage": "https://github.com/keshavkaul/react-native-sketch-view#readme",
-  
+
   "peerDependencies": {
-    "react-native": "^0.42.0"
+    "react-native": "^0.45.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "homepage": "https://github.com/keshavkaul/react-native-sketch-view#readme",
 
   "peerDependencies": {
-    "react-native": "^0.42"
+    "react-native": "~0.42"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "homepage": "https://github.com/keshavkaul/react-native-sketch-view#readme",
 
   "peerDependencies": {
-    "react-native": "~0.42"
+    "react-native": "0.x"
   }
 }


### PR DESCRIPTION
This will stop throwing warnings on version `0.x`, but explicitly handles all advices compatibility changes through 0.47 as far as I know.

Fixes #12 