### PR TITLE
[iOS] Saves image with transparency mask

### DIFF
--- a/ios/SketchView/SketchViewContainer.m
+++ b/ios/SketchView/SketchViewContainer.m
@@ -41,11 +41,17 @@
 
 + (UIImage *) imageWithView:(UIView *)view
 {
-    UIGraphicsBeginImageContextWithOptions(view.bounds.size, view.opaque, [[UIScreen mainScreen] scale]);
+    UIGraphicsBeginImageContext(view.bounds.size);
     [view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    
+    const CGFloat mask[6] = { 222, 255, 222, 255, 222, 255 };
     UIImage * img = UIGraphicsGetImageFromCurrentImageContext();
+    CGImageRef imageMask = CGImageCreateWithMaskingColors(img.CGImage, mask);
+    UIImage * maskedImage = UIGraphicsGetImageFromCurrentImageContext();
+    
+    CGImageRelease(imageMask);
     UIGraphicsEndImageContext();
-    return img;
+    return maskedImage;
 }
 
 @end


### PR DESCRIPTION
Saving images after removing the `View` container's background, or setting it to transparent would result in an all-black image after saving on iOS only.

This PR aims to resolve this by creating the image with a transparency mask.

I realize now that I've removed the scale option from the call to `UIGraphicsBeginImageContext`, so let me know if this poses problems.

This issue was also raised in Issue https://github.com/keshavkaul/react-native-sketch-view/issues/23

Before:
<img width="375" alt="before" src="https://user-images.githubusercontent.com/3951747/34920195-b55d2af8-f923-11e7-825b-1f1a9b310ddf.png">

After:
![after](https://user-images.githubusercontent.com/3951747/34920198-ba2ec046-f923-11e7-9a2e-bba6c3364d10.png)
