### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
 import { 
   requireNativeComponent, 
   View,
@@ -7,6 +7,7 @@ import {
   findNodeHandle,
   DeviceEventEmitter 
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 class SketchView extends Component {
   constructor(props) {


### PR DESCRIPTION
React no longer includes PropTypes.

Starting with react version 16, PropTypes has been moved to a separate package. PropTypes is now found in the npm package prop-types.