### PR TITLE
Convert all tool's touchView reference to `weak` (breaks retain cycle)

### DIFF
--- a/ios/RNSketchView.xcodeproj/project.pbxproj
+++ b/ios/RNSketchView.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 				6B5936381E9BAF4E0075024B /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		6B37E2331E9D41ED006883C6 /* Tools */ = {
 			isa = PBXGroup;

--- a/ios/SketchView/Tools/PathTrackingSketchTool.m
+++ b/ios/SketchView/Tools/PathTrackingSketchTool.m
@@ -35,7 +35,7 @@
 {
     if (!self.touchView) return;
 
-	UITouch *touch = [touches anyObject];
+    UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
     [_path addLineToPoint:point];
     [self.touchView setNeedsDisplay];
@@ -45,7 +45,7 @@
 {
     if (!self.touchView) return;
 
-	UITouch *touch = [touches anyObject];
+    UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
     [_path addLineToPoint:point];
     [self.touchView setNeedsDisplay];

--- a/ios/SketchView/Tools/PathTrackingSketchTool.m
+++ b/ios/SketchView/Tools/PathTrackingSketchTool.m
@@ -24,7 +24,7 @@
 
 -(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-	if (!self.touchView) return;
+    if (!self.touchView) return;
 
     UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
@@ -33,7 +33,7 @@
 
 -(void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-	if (!self.touchView) return;
+    if (!self.touchView) return;
 
 	UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
@@ -43,7 +43,7 @@
 
 -(void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-	if (!self.touchView) return;
+    if (!self.touchView) return;
 
 	UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];

--- a/ios/SketchView/Tools/PathTrackingSketchTool.m
+++ b/ios/SketchView/Tools/PathTrackingSketchTool.m
@@ -24,6 +24,8 @@
 
 -(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+	if (!self.touchView) return;
+
     UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
     [_path moveToPoint:point];
@@ -31,7 +33,9 @@
 
 -(void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    UITouch *touch = [touches anyObject];
+	if (!self.touchView) return;
+
+	UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
     [_path addLineToPoint:point];
     [self.touchView setNeedsDisplay];
@@ -39,7 +43,9 @@
 
 -(void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    UITouch *touch = [touches anyObject];
+	if (!self.touchView) return;
+
+	UITouch *touch = [touches anyObject];
     CGPoint point = [touch locationInView:self.touchView];
     [_path addLineToPoint:point];
     [self.touchView setNeedsDisplay];

--- a/ios/SketchView/Tools/SketchTool.h
+++ b/ios/SketchView/Tools/SketchTool.h
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSInteger, SketchToolType) {
 
 @interface SketchTool : NSObject
 
-@property UIView *touchView;
+@property (nonatomic, weak) UIView *touchView;
 
 -(instancetype)initWithTouchView:(UIView *) touchView;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "react-native-sketch-view",
-  "version": "1.0.1",
-  "description": "A React Native component for touch based drawing supporting iOS and Android.",
+  "version": "1.0.2",
+  "description":
+    "A React Native component for touch based drawing supporting iOS and Android.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Fixes https://github.com/keshavkaul/react-native-sketch-view/issues/35

This breaks the strong reference retain cycle between the SketchView and the tools it works with. Given that the tools won't exist without a view, they now have a weak reference back to the touch view. 